### PR TITLE
Added `babel__core` to template

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
+    "@types/babel__core": "^7.1.14",
     "@react-native-community/eslint-config": "^2.0.0",
     "@svgr/cli": "^5.5.0",
     "@types/jest": "^26.0.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1305,7 +1305,7 @@
     deepmerge "^4.2.2"
     svgo "^1.2.2"
 
-"@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
+"@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14", "@types/babel__core@^7.1.7":
   version "7.1.14"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.14.tgz#faaeefc4185ec71c389f4501ee5ec84b170cc402"
   integrity sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==


### PR DESCRIPTION
Template built successfully but there was a problem that tells us about a missing a type definition file for the module `babel__core`. This pull request fixes it.

Link to the issue: https://github.com/microsoft/TypeScript-Babel-Starter/issues/51